### PR TITLE
fix invalid contract check

### DIFF
--- a/contracts/market/ZestyMarket_ERC20_V1_1.sol
+++ b/contracts/market/ZestyMarket_ERC20_V1_1.sol
@@ -619,7 +619,7 @@ contract ZestyMarket_ERC20_V1_1 is ZestyVault, ReentrancyGuard {
                 "ZestyMarket_ERC20_V1::contractWithdrawBatch: Not seller or operator"
             );
             require(
-                c.sellerAuctionId != 0 || c.buyerCampaignId != 0,
+                c.sellerAuctionId != 0 && c.buyerCampaignId != 0,
                 "ZestyMarket_ERC20_V1::contractWithdrawBatch: Invalid contract"
             );
             require(

--- a/contracts/market/ZestyMarket_ERC20_V2.sol
+++ b/contracts/market/ZestyMarket_ERC20_V2.sol
@@ -795,7 +795,7 @@ contract ZestyMarket_ERC20_V2 is ZestyVault, RewardsRecipient, ReentrancyGuard {
                 "ZestyMarket_ERC20_V2::contractWithdrawBatch: Not seller or operator"
             );
             require(
-                c.sellerAuctionId != 0 || c.buyerCampaignId != 0,
+                c.sellerAuctionId != 0 && c.buyerCampaignId != 0,
                 "ZestyMarket_ERC20_V2::contractWithdrawBatch: Invalid contract"
             );
             require(


### PR DESCRIPTION
The previous `||` operator caused insolvency problems in the market contract as sellers would be able to withdraw with an invalid buyerCampaignId. This has been changed to `&&`